### PR TITLE
Fix zero-knowledge paste redirect

### DIFF
--- a/account.php
+++ b/account.php
@@ -41,7 +41,7 @@ $stmt = $db->prepare("SELECT COUNT(*) as total_pastes FROM pastes WHERE user_id 
 $stmt->execute([$user_id]);
 $total_pastes = $stmt->fetch()['total_pastes'];
 
-$stmt = $db->prepare("SELECT COUNT(*) as public_pastes FROM pastes WHERE user_id = ? AND is_public = 1");
+$stmt = $db->prepare("SELECT COUNT(*) as public_pastes FROM pastes WHERE user_id = ? AND is_public = 1 AND zero_knowledge = 0");
 $stmt->execute([$user_id]);
 $public_pastes = $stmt->fetch()['public_pastes'];
 

--- a/enhanced_paste_share.php
+++ b/enhanced_paste_share.php
@@ -66,7 +66,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
         }
         
         // Get paste info
-        $stmt = $db->prepare("SELECT * FROM pastes WHERE id = ? AND is_public = 1");
+        $stmt = $db->prepare("SELECT * FROM pastes WHERE id = ? AND is_public = 1 AND zero_knowledge = 0");
         $stmt->execute([$paste_id]);
         $paste = $stmt->fetch(PDO::FETCH_ASSOC);
         

--- a/following.php
+++ b/following.php
@@ -79,7 +79,7 @@ if ($tab === 'following') {
                uf.created_at as followed_at
         FROM user_follows uf 
         JOIN users u ON uf.following_id = u.id
-        LEFT JOIN pastes p ON u.id = p.user_id AND p.is_public = 1
+        LEFT JOIN pastes p ON u.id = p.user_id AND p.is_public = 1 AND p.zero_knowledge = 0
         WHERE uf.follower_id = ?
         GROUP BY u.id, u.username, u.profile_image, u.tagline, uf.created_at
         ORDER BY uf.created_at DESC
@@ -97,7 +97,7 @@ if ($tab === 'followers') {
                uf.created_at as followed_at
         FROM user_follows uf 
         JOIN users u ON uf.follower_id = u.id
-        LEFT JOIN pastes p ON u.id = p.user_id AND p.is_public = 1
+        LEFT JOIN pastes p ON u.id = p.user_id AND p.is_public = 1 AND p.zero_knowledge = 0
         WHERE uf.following_id = ?
         GROUP BY u.id, u.username, u.profile_image, u.tagline, uf.created_at
         ORDER BY uf.created_at DESC
@@ -114,7 +114,7 @@ if ($tab === 'discover') {
                COUNT(p.id) as paste_count,
                u.followers_count
         FROM users u
-        LEFT JOIN pastes p ON u.id = p.user_id AND p.is_public = 1
+        LEFT JOIN pastes p ON u.id = p.user_id AND p.is_public = 1 AND p.zero_knowledge = 0
         WHERE u.id != ? 
         AND u.id NOT IN (SELECT following_id FROM user_follows WHERE follower_id = ?)
         GROUP BY u.id, u.username, u.profile_image, u.tagline, u.followers_count

--- a/index.php
+++ b/index.php
@@ -33,16 +33,16 @@ if (isset($_GET['logout'])) {
     if ($_GET['action'] === 'load_children') {
       $parent_id = $_GET['parent_id'] ?? '';
       if ($parent_id) {
-        $stmt = $db->prepare("
-          SELECT p.*, u.username,
+        $stmt = $db->prepare(
+          "SELECT p.*, u.username,
           (SELECT COUNT(*) FROM comments WHERE paste_id = p.id) as comment_count,
           COALESCE(p.fork_count, 0) as fork_count
-          FROM pastes p 
+          FROM pastes p
           LEFT JOIN users u ON p.user_id = u.id
-          WHERE p.parent_paste_id = ? AND p.is_public = 1
+          WHERE p.parent_paste_id = ? AND p.is_public = 1 AND p.zero_knowledge = 0
           AND (p.expire_time IS NULL OR p.expire_time > ?)
-          ORDER BY p.created_at ASC
-        ");
+          ORDER BY p.created_at ASC"
+        );
         $stmt->execute([$parent_id, time()]);
         $children = $stmt->fetchAll();
 
@@ -326,7 +326,8 @@ try {
     tags TEXT DEFAULT '',
     views INTEGER DEFAULT 0,
     user_id TEXT,
-    burn_after_read BOOLEAN DEFAULT 0
+    burn_after_read BOOLEAN DEFAULT 0,
+    zero_knowledge INTEGER DEFAULT 0
   )");
 
   // Add table for tracking unique views
@@ -351,6 +352,9 @@ try {
   }
   if (!in_array('collection_id', $columns)) {
     $db->exec("ALTER TABLE pastes ADD COLUMN collection_id INTEGER DEFAULT NULL");
+  }
+  if (!in_array('zero_knowledge', $columns)) {
+    $db->exec("ALTER TABLE pastes ADD COLUMN zero_knowledge INTEGER DEFAULT 0");
   }
 
 
@@ -1245,8 +1249,8 @@ if __name__ == "__main__":
 
       try {
         $stmt = $db->prepare(
-          "INSERT INTO pastes (title, content, language, password, expire_time, is_public, tags, user_id, created_at, burn_after_read, current_version, last_modified, collection_id, original_paste_id, parent_paste_id) 
-           VALUES (:title, :content, :language, :password, :expire_time, :is_public, :tags, :user_id, :created_at, :burn_after_read, 1, :created_at, :collection_id, :original_paste_id, :parent_paste_id)"
+          "INSERT INTO pastes (title, content, language, password, expire_time, is_public, tags, user_id, created_at, burn_after_read, zero_knowledge, current_version, last_modified, collection_id, original_paste_id, parent_paste_id)
+           VALUES (:title, :content, :language, :password, :expire_time, :is_public, :tags, :user_id, :created_at, :burn_after_read, :zero_knowledge, 1, :created_at, :collection_id, :original_paste_id, :parent_paste_id)"
         );
 
       $expire_time = null;
@@ -1283,6 +1287,7 @@ if __name__ == "__main__":
         ':user_id' => $user_id,
         ':created_at' => time(),
         ':burn_after_read' => isset($_POST['burn_after_read']) ? 1 : 0,
+        ':zero_knowledge' => isset($_POST['zero_knowledge']) ? 1 : 0,
         ':collection_id' => !empty($_POST['collection_id']) ? $_POST['collection_id'] : null,
         ':original_paste_id' => !empty($original_paste_id) ? $original_paste_id : null,
         ':parent_paste_id' => !empty($_POST['parent_paste_id']) ? $_POST['parent_paste_id'] : null
@@ -1364,7 +1369,8 @@ if __name__ == "__main__":
        password = :password,
        expire_time = :expire_time,
        is_public = :is_public,
-       tags = :tags
+       tags = :tags,
+       zero_knowledge = :zero_knowledge
        WHERE id = :id AND user_id = :user_id"
     );
 
@@ -1384,6 +1390,7 @@ if __name__ == "__main__":
       ':expire_time' => $expire_time,
       ':is_public' => isset($_POST['is_public']) ? 1 : 0,
       ':tags' => $tags,
+      ':zero_knowledge' => isset($_POST['zero_knowledge']) ? 1 : 0,
       ':id' => $_POST['id'],
       ':user_id' => $user_id
     ]);
@@ -1528,7 +1535,7 @@ if __name__ == "__main__":
   }
 
   // List public pastes with search and filtering
-  $where = ["p.is_public = 1", "(p.expire_time IS NULL OR p.expire_time > " . time() . ")"];
+  $where = ["p.is_public = 1", "p.zero_knowledge = 0", "(p.expire_time IS NULL OR p.expire_time > " . time() . ")"];
   if (isset($_GET['search'])) {
     $search = '%' . $_GET['search'] . '%';
     $where[] = "(p.title LIKE ? OR p.content LIKE ? OR p.tags LIKE ?)";
@@ -1554,7 +1561,7 @@ if __name__ == "__main__":
 
   // Handle latest pastes request
   if (isset($_GET['action']) && $_GET['action'] === 'latest_pastes') {
-    $stmt = $db->prepare("SELECT p.*, u.username FROM pastes p LEFT JOIN users u ON p.user_id = u.id WHERE p.is_public = 1 AND (p.expire_time IS NULL OR p.expire_time > ?) ORDER BY p.created_at DESC LIMIT 5");
+    $stmt = $db->prepare("SELECT p.*, u.username FROM pastes p LEFT JOIN users u ON p.user_id = u.id WHERE p.is_public = 1 AND p.zero_knowledge = 0 AND (p.expire_time IS NULL OR p.expire_time > ?) ORDER BY p.created_at DESC LIMIT 5");
     $stmt->execute([time()]);
     $latestPastes = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
@@ -2244,7 +2251,7 @@ $theme = $_COOKIE['theme'] ?? 'dark';
                     $related_count = count($related_pastes);
 
                     // Get chain count (children)
-                    $stmt = $db->prepare("SELECT COUNT(*) FROM pastes WHERE parent_paste_id = ? AND is_public = 1");
+                    $stmt = $db->prepare("SELECT COUNT(*) FROM pastes WHERE parent_paste_id = ? AND is_public = 1 AND zero_knowledge = 0");
                     $stmt->execute([$paste['id']]);
                     $chain_count = $stmt->fetchColumn();
                     ?>
@@ -2255,18 +2262,24 @@ $theme = $_COOKIE['theme'] ?? 'dark';
                         <button onclick="copyText(document.querySelector('pre code')?.textContent)" class="p-2 rounded bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors" title="Copy code">
                           <i class="fas fa-copy text-sm"></i>
                         </button>
-                        <a href="?id=<?= $paste['id'] ?>&raw=1" target="_blank" class="p-2 rounded bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 inline-flex transition-colors" title="View raw">
+                        <a href="?id=<?= $paste['id'] ?>&raw=1" target="_blank" class="p-2 rounded bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 inline-flex transition-colors zk-restricted<?= $paste['zero_knowledge'] ? ' hidden' : '' ?>" title="View raw">
                           <i class="fas fa-code text-sm"></i>
                         </a>
-                        <a href="?id=<?= $paste['id'] ?>&download=1" class="p-2 rounded bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 inline-flex transition-colors" title="Download">
-                          <i class="fas fa-download text-sm"></i>
-                        </a>
-                        <button onclick="clonePaste()" class="p-2 rounded bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors" title="Clone">
+                        <?php if ($paste['zero_knowledge']): ?>
+                          <a href="#" onclick="downloadPaste('<?= preg_replace('/[^a-zA-Z0-9]+/', '_', $paste['title']) ?>'); return false;" class="p-2 rounded bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 inline-flex transition-colors zk-restricted hidden" title="Download">
+                            <i class="fas fa-download text-sm"></i>
+                          </a>
+                        <?php else: ?>
+                          <a href="?id=<?= $paste['id'] ?>&download=1" class="p-2 rounded bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 inline-flex transition-colors" title="Download">
+                            <i class="fas fa-download text-sm"></i>
+                          </a>
+                        <?php endif; ?>
+                        <button onclick="clonePaste()" class="p-2 rounded bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors zk-restricted<?= $paste['zero_knowledge'] ? ' hidden' : '' ?>" title="Clone">
                           <i class="fas fa-clone text-sm"></i>
                         </button>
                       <?php endif; ?>
 
-                      <button onclick="window.location.href='/?parent_id=<?= $paste['id'] ?>'" class="p-2 rounded bg-green-500 text-white hover:bg-green-600 transition-colors" title="Add to Chain">
+                      <button onclick="window.location.href='/?parent_id=<?= $paste['id'] ?>'" class="p-2 rounded bg-green-500 text-white hover:bg-green-600 transition-colors zk-restricted<?= $paste['zero_knowledge'] ? ' hidden' : '' ?>" title="Add to Chain">
                         <i class="fas fa-link text-sm"></i>
                       </button>
 
@@ -2280,7 +2293,7 @@ $theme = $_COOKIE['theme'] ?? 'dark';
                         }
                         ?>
                         <?php if (!$already_forked): ?>
-                          <button onclick="forkPaste(<?= $paste['id'] ?>)" class="p-2 rounded bg-purple-500 text-white hover:bg-purple-600 transition-colors" title="Fork">
+                          <button onclick="forkPaste(<?= $paste['id'] ?>)" class="p-2 rounded bg-purple-500 text-white hover:bg-purple-600 transition-colors zk-restricted<?= $paste['zero_knowledge'] ? ' hidden' : '' ?>" title="Fork">
                             <i class="fas fa-code-branch text-sm"></i>
                           </button>
                         <?php endif; ?>
@@ -2326,7 +2339,7 @@ $theme = $_COOKIE['theme'] ?? 'dark';
                       <i class="fas fa-code-branch mr-2"></i>Forks <span class="ml-1 px-2 py-0.5 bg-gray-200 dark:bg-gray-600 rounded-full text-xs"><?= $fork_count ?></span>
                     </button>
                   <?php endif; ?>
-                  <button onclick="switchPasteTab('comments')" id="paste-tab-comments" class="paste-tab px-6 py-4 text-sm font-medium border-b-2 border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300 transition-all duration-200" role="tab">
+                  <button onclick="switchPasteTab('comments')" id="paste-tab-comments" class="paste-tab px-6 py-4 text-sm font-medium border-b-2 border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300 transition-all duration-200 zk-restricted<?= $paste['zero_knowledge'] ? ' hidden' : '' ?>" role="tab">
                     <i class="fas fa-comment mr-2"></i>Comments <span class="ml-1 px-2 py-0.5 bg-gray-200 dark:bg-gray-600 rounded-full text-xs"><?= $comment_count ?></span>
                   </button>
                   <?php
@@ -2335,7 +2348,7 @@ $theme = $_COOKIE['theme'] ?? 'dark';
                   $stmt->execute([$paste['id']]);
                   $discussion_count = $stmt->fetchColumn();
                   ?>
-                  <button onclick="switchPasteTab('discussions')" id="paste-tab-discussions" class="paste-tab px-6 py-4 text-sm font-medium border-b-2 border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300 transition-all duration-200" role="tab">
+                  <button onclick="switchPasteTab('discussions')" id="paste-tab-discussions" class="paste-tab px-6 py-4 text-sm font-medium border-b-2 border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300 transition-all duration-200 zk-restricted<?= $paste['zero_knowledge'] ? ' hidden' : '' ?>" role="tab">
                     <i class="fas fa-comments mr-2"></i>Discussions <span class="ml-1 px-2 py-0.5 bg-gray-200 dark:bg-gray-600 rounded-full text-xs"><?= $discussion_count ?></span>
                   </button>
                 </nav>
@@ -2444,6 +2457,14 @@ $theme = $_COOKIE['theme'] ?? 'dark';
                             <div class="mt-4 text-gray-600 dark:text-gray-400">
                               <p class="text-sm">If you believe this is an error, please contact support.</p>
                             </div>
+                          </div>
+                        <?php elseif ($paste['zero_knowledge']): ?>
+                          <div id="zkBanner" class="bg-yellow-100 dark:bg-yellow-900 p-4 rounded mb-2 text-center text-sm">
+                            This is a Zero-Knowledge Paste. Only users with the full link can decrypt it.
+                            <div id="zkPrivateLink" class="mt-2 break-words"></div>
+                          </div>
+                          <div class="bg-gray-100 dark:bg-gray-800 rounded-lg overflow-hidden">
+                            <pre id="zkContent" class="p-4 whitespace-pre-wrap break-words" style="font-family: monospace;"></pre>
                           </div>
                         <?php else: ?>
                           <!-- Normal content display -->
@@ -2643,7 +2664,7 @@ $theme = $_COOKIE['theme'] ?? 'dark';
                     SELECT p.*, u.username, u.profile_image
                     FROM pastes p
                     LEFT JOIN users u ON p.user_id = u.id
-                    WHERE p.parent_paste_id = ? AND p.is_public = 1
+                    WHERE p.parent_paste_id = ? AND p.is_public = 1 AND p.zero_knowledge = 0
                     ORDER BY p.created_at ASC
                     LIMIT 10
                   ");
@@ -2782,7 +2803,7 @@ $theme = $_COOKIE['theme'] ?? 'dark';
                 <?php endif; ?>
 
                 <!-- Discussions Tab -->
-                <div id="paste-content-discussions" class="tab-content hidden" role="tabpanel">
+                <div id="paste-content-discussions" class="tab-content hidden zk-restricted<?= $paste['zero_knowledge'] ? ' hidden' : '' ?>" role="tabpanel">
                   <div class="space-y-6">
                     <div class="flex justify-between items-center">
                       <h3 class="text-lg font-medium">
@@ -3076,7 +3097,7 @@ $theme = $_COOKIE['theme'] ?? 'dark';
                 </div>
 
                 <!-- Comments Tab -->
-                <div id="paste-content-comments" class="tab-content hidden" role="tabpanel">
+                <div id="paste-content-comments" class="tab-content hidden zk-restricted<?= $paste['zero_knowledge'] ? ' hidden' : '' ?>" role="tabpanel">
                   <div class="space-y-6">
                     <h3 class="text-lg font-medium">
                       <i class="fas fa-comment mr-2 text-green-500"></i>Comments (<?= $comment_count ?>)
@@ -3469,7 +3490,17 @@ $theme = $_COOKIE['theme'] ?? 'dark';
                 document.body.innerHTML = printContent;
               }
 
-              function forkPaste(pasteId) {
+      function forkPaste(pasteId) {
+        <?php if ($paste['zero_knowledge']): ?>
+          if (!window.pasteDecrypted) {
+            Swal.fire({
+              icon: 'warning',
+              title: 'Action Disabled',
+              text: 'This action is disabled for encrypted pastes. Please provide the decryption key first.'
+            });
+            return;
+          }
+        <?php endif; ?>
         <?php if (!$user_id): ?>
           // For anonymous users: store fork data and redirect to create form
           Swal.fire({
@@ -3533,6 +3564,16 @@ $theme = $_COOKIE['theme'] ?? 'dark';
       }
 
       function clonePaste() {
+                <?php if ($paste['zero_knowledge']): ?>
+                  if (!window.pasteDecrypted) {
+                    Swal.fire({
+                      icon: 'warning',
+                      title: 'Action Disabled',
+                      text: 'This action is disabled for encrypted pastes. Please provide the decryption key first.'
+                    });
+                    return;
+                  }
+                <?php endif; ?>
                 <?php if ($is_flagged_for_blur): ?>
                   Swal.fire({
                     icon: 'warning',
@@ -3595,6 +3636,26 @@ $theme = $_COOKIE['theme'] ?? 'dark';
                     timer: 2000
                   });
                 }
+              }
+
+              function downloadPaste(filename) {
+                if (!window.pasteDecrypted || !window.decryptedText) {
+                  Swal.fire({
+                    icon: 'warning',
+                    title: 'Action Disabled',
+                    text: 'This action is disabled for encrypted pastes. Please provide the decryption key first.'
+                  });
+                  return;
+                }
+                const blob = new Blob([window.decryptedText], { type: 'text/plain' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = filename || 'paste.txt';
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+                URL.revokeObjectURL(url);
               }
 
               // Report paste function
@@ -5965,277 +6026,21 @@ plt.show()</code></pre>
           <?php if (isset($_GET['page']) && $_GET['page'] === 'archive'): ?>
             <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6">
               <h2 class="text-2xl font-bold mb-6">
-                <i class="fas fa-archive mr-2"></i>Global Search & Archive
+                <i class="fas fa-archive mr-2"></i>Archive
               </h2>
-
-              <!-- Sleek Search Section -->
-              <div class="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4">
-                <form method="GET" id="searchForm">
-                  <input type="hidden" name="page" value="archive">
-
-                  <!-- Main Search Row -->
-                  <div class="flex flex-col lg:flex-row gap-3">
-                    <!-- Search Input -->
-                    <div class="flex-1">
-                      <div class="relative">
-                        <i class="fas fa-search absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400"></i>
-                        <input type="text" 
-                               name="search" 
-                               value="<?= htmlspecialchars($_GET['search'] ?? '') ?>"
-                               placeholder="Search pastes, content, or tags..."
-                               class="w-full pl-10 pr-4 py-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent">
-                      </div>
-                    </div>
-
-                    <!-- Language Filter -->
-                    <div class="min-w-0 lg:w-40">
-                      <select name="language" class="w-full px-3 py-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-sm focus:ring-2 focus:ring-blue-500">
-                        <option value="">All Languages</option>
-                        <?php
-                        $lang_stmt = $db->query("SELECT DISTINCT language FROM pastes WHERE is_public = 1 AND (expire_time IS NULL OR expire_time > " . time() . ") ORDER BY language");
-                        $languages = $lang_stmt->fetchAll(PDO::FETCH_COLUMN);
-                        foreach ($languages as $lang):
-                        ?>
-                          <option value="<?= htmlspecialchars($lang) ?>" <?= ($_GET['language'] ?? '') === $lang ? 'selected' : '' ?>>
-                            <?= htmlspecialchars(ucfirst($lang)) ?>
-                          </option>
-                        <?php endforeach; ?>
-                      </select>
-                    </div>
-
-                    <!-- Sort Filter -->
-                    <div class="min-w-0 lg:w-36">
-                      <select name="sort_by" class="w-full px-3 py-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-sm focus:ring-2 focus:ring-blue-500">
-                        <option value="created_at_desc" <?= ($_GET['sort_by'] ?? 'created_at_desc') === 'created_at_desc' ? 'selected' : '' ?>>Newest</option>
-                        <option value="views_desc" <?= ($_GET['sort_by'] ?? '') === 'views_desc' ? 'selected' : '' ?>>Popular</option>
-                        <option value="created_at_asc" <?= ($_GET['sort_by'] ?? '') === 'created_at_asc' ? 'selected' : '' ?>>Oldest</option>
-                        <option value="title_asc" <?= ($_GET['sort_by'] ?? '') === 'title_asc' ? 'selected' : '' ?>>A-Z</option>
-                      </select>
-                    </div>
-
-                    <!-- Search Button -->
-                    <button type="submit" class="px-6 py-2.5 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors flex items-center justify-center">
-                      <i class="fas fa-search lg:mr-2"></i>
-                      <span class="hidden lg:inline">Search</span>
-                    </button>
-
-                    <!-- Advanced Toggle -->
-                    <button type="button" onclick="toggleAdvancedFilters()" class="px-3 py-2.5 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
-                      <i class="fas fa-sliders-h"></i>
-                    </button>
-                  </div>
-
-                  <!-- Advanced Filters (Hidden by default) -->
-                  <div id="advancedFilters" class="hidden mt-4 pt-4 border-t border-gray-200 dark:border-gray-600">
-                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
-                      <div>
-                        <input type="text" 
-                               name="user" 
-                               value="<?= htmlspecialchars($_GET['user'] ?? '') ?>"
-                               placeholder="Author username..."
-                               class="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-sm">
-                      </div>
-                      <div>
-                        <input type="text" 
-                               name="tags" 
-                               value="<?= htmlspecialchars($_GET['tags'] ?? '') ?>"
-                               placeholder="Tags (comma separated)..."
-                               class="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-sm">
-                      </div>
-                      <div>
-                        <input type="date" 
-                               name="date_from" 
-                               value="<?= htmlspecialchars($_GET['date_from'] ?? '') ?>"
-                               class="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-sm">
-                      </div>
-                      <div>
-                        <input type="date" 
-                               name="date_to" 
-                               value="<?= htmlspecialchars($_GET['date_to'] ?? '') ?>"
-                               class="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-sm">
-                      </div>
-                    </div>
-                    <div class="mt-3 flex gap-2">
-                      <a href="?page=archive" class="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200">
-                        Clear All Filters
-                      </a>
-                    </div>
-                  </div>
-                </form>
-
-                <!-- Quick Filter Pills (More Compact) -->
-                <?php if (empty($_GET['search']) && empty($_GET['language']) && empty($_GET['user'])): ?>
-                <div class="mt-3 flex flex-wrap gap-2">
-                  <button onclick="quickFilter('language', 'javascript')" class="px-3 py-1 bg-yellow-50 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300 rounded-full text-xs hover:bg-yellow-100 dark:hover:bg-yellow-900/50 transition-colors">JavaScript</button>
-                  <button onclick="quickFilter('language', 'python')" class="px-3 py-1 bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300 rounded-full text-xs hover:bg-green-100 dark:hover:bg-green-900/50 transition-colors">Python</button>
-                  <button onclick="quickFilter('language', 'php')" class="px-3 py-1 bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 rounded-full text-xs hover:bg-purple-100 dark:hover:bg-purple-900/50 transition-colors">PHP</button>
-                  <button onclick="quickFilter('sort_by', 'views_desc')" class="px-3 py-1 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded-full text-xs hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors">Popular</button>
-                </div>
-                <?php endif; ?>
-              </div>
-
-              <!-- Search Results Summary -->
-              <?php
-              // Build search conditions
-              $search_conditions = ["p.is_public = 1", "(p.expire_time IS NULL OR p.expire_time > ?)", "p.parent_paste_id IS NULL"];
-              $search_params = [time()];
-
-              // Add search term
-              if (!empty($_GET['search'])) {
-                $search_conditions[] = "(p.title LIKE ? OR p.content LIKE ? OR p.tags LIKE ?)";
-                $search_term = '%' . $_GET['search'] . '%';
-                $search_params = array_merge($search_params, [$search_term, $search_term, $search_term]);
-              }
-
-              // Add language filter
-              if (!empty($_GET['language'])) {
-                $search_conditions[] = "p.language = ?";
-                $search_params[] = $_GET['language'];
-              }
-
-              // Add user filter
-              if (!empty($_GET['user'])) {
-                $search_conditions[] = "u.username LIKE ?";
-                $search_params[] = '%' . $_GET['user'] . '%';
-              }
-
-              // Add tags filter
-              if (!empty($_GET['tags'])) {
-                $tags = explode(',', $_GET['tags']);
-                $tag_conditions = [];
-                foreach ($tags as $tag) {
-                  $tag = trim($tag);
-                  if ($tag) {
-                    $tag_conditions[] = "p.tags LIKE ?";
-                    $search_params[] = '%' . $tag . '%';
-                  }
-                }
-                if (!empty($tag_conditions)) {
-                  $search_conditions[] = "(" . implode(" OR ", $tag_conditions) . ")";
-                }
-              }
-
-              // Add date filters
-              if (!empty($_GET['date_from'])) {
-                $search_conditions[] = "p.created_at >= ?";
-                $search_params[] = strtotime($_GET['date_from']);
-              }
-
-              if (!empty($_GET['date_to'])) {
-                $search_conditions[] = "p.created_at <= ?";
-                $search_params[] = strtotime($_GET['date_to'] . ' 23:59:59');
-              }
-
-              // Build ORDER BY clause
-              $sort_by = $_GET['sort_by'] ?? 'created_at_desc';
-              switch($sort_by) {
-                case 'created_at_asc':
-                  $order_clause = 'ORDER BY p.created_at ASC';
-                  break;
-                case 'views_desc':
-                  $order_clause = 'ORDER BY p.views DESC';
-                  break;
-                case 'views_asc':
-                  $order_clause = 'ORDER BY p.views ASC';
-                  break;
-                case 'title_asc':
-                  $order_clause = 'ORDER BY p.title ASC';
-                  break;
-                case 'title_desc':
-                  $order_clause = 'ORDER BY p.title DESC';
-                  break;
-                default:
-                  $order_clause = 'ORDER BY p.created_at DESC';
-                  break;
-              }
-
-              // Get total count with filters
-              $count_query = "
-                SELECT COUNT(*) as total 
-                FROM pastes p
-                LEFT JOIN users u ON p.user_id = u.id
-                WHERE " . implode(" AND ", $search_conditions);
-
-              $count_stmt = $db->prepare($count_query);
-              $count_stmt->execute($search_params);
-              $total_count = $count_stmt->fetch()['total'];
-
-              // Pagination
-              // Limit archive view to 5 pastes per page
-              $items_per_page = 5;
-              $current_page = isset($_GET['p']) ? max(1, intval($_GET['p'])) : 1;
-              $offset = ($current_page - 1) * $items_per_page;
-              $total_pages = ceil($total_count / $items_per_page);
-
-              // Get filtered results
-              $results_query = "
-                SELECT p.*, u.username,
-                (SELECT COUNT(*) FROM comments WHERE paste_id = p.id) as comment_count,
-                COALESCE(p.fork_count, 0) as fork_count,
-                CASE WHEN p.original_paste_id IS NOT NULL THEN 1 ELSE 0 END as is_fork,
-                p.original_paste_id,
-                p.parent_paste_id,
-                (SELECT COUNT(*) FROM pastes WHERE parent_paste_id = p.id AND is_public = 1) as child_count
-                FROM pastes p 
-                LEFT JOIN users u ON p.user_id = u.id
-                WHERE " . implode(" AND ", $search_conditions) . "
-                {$order_clause}
-                LIMIT ? OFFSET ?";
-
-              $search_params[] = $items_per_page;
-              $search_params[] = $offset;
-
-              $stmt = $db->prepare($results_query);
-              $stmt->execute($search_params);
-              $archive_pastes = $stmt->fetchAll();
-              ?>
-
-              <?php if (!empty($_GET['search']) || !empty($_GET['language']) || !empty($_GET['user']) || !empty($_GET['tags']) || !empty($_GET['date_from']) || !empty($_GET['date_to'])): ?>
-              <div class="mb-4 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
-                <div class="flex items-center justify-between">
-                  <div>
-                    <h3 class="text-lg font-medium text-blue-800 dark:text-blue-200">
-                      <i class="fas fa-search mr-2"></i>Search Results
-                    </h3>
-                    <p class="text-blue-600 dark:text-blue-300">
-                      Found <?= number_format($total_count) ?> paste<?= $total_count !== 1 ? 's' : '' ?>
-                      <?php if (!empty($_GET['search'])): ?>
-                        matching "<?= htmlspecialchars($_GET['search']) ?>"
-                      <?php endif; ?>
-                    </p>
-                  </div>
-                  <a href="?page=archive" class="text-blue-600 dark:text-blue-300 hover:text-blue-800 dark:hover:text-blue-100">
-                    <i class="fas fa-times mr-1"></i>Clear Filters
-                  </a>
-                </div>
-
-                <!-- Active Filters -->
-                <div class="mt-3 flex flex-wrap gap-2">
-                  <?php if (!empty($_GET['search'])): ?>
-                    <span class="inline-flex items-center px-3 py-1 bg-blue-100 dark:bg-blue-800 text-blue-800 dark:text-blue-200 rounded-full text-sm">
-                      Search: "<?= htmlspecialchars($_GET['search']) ?>"
-                    </span>
-                  <?php endif; ?>
-                  <?php if (!empty($_GET['language'])): ?>
-                    <span class="inline-flex items-center px-3 py-1 bg-green-100 dark:bg-green-800 text-green-800 dark:text-green-200 rounded-full text-sm">
-                      Language: <?= htmlspecialchars($_GET['language']) ?>
-                    </span>
-                  <?php endif; ?>
-                  <?php if (!empty($_GET['user'])): ?>
-                    <span class="inline-flex items-center px-3 py-1 bg-purple-100 dark:bg-purple-800 text-purple-800 dark:text-purple-200 rounded-full text-sm">
-                      Author: <?= htmlspecialchars($_GET['user']) ?>
-                    </span>
-                  <?php endif; ?>
-                  <?php if (!empty($_GET['tags'])): ?>
-                    <span class="inline-flex items-center px-3 py-1 bg-yellow-100 dark:bg-yellow-800 text-yellow-800 dark:text-yellow-200 rounded-full text-sm">
-                      Tags: <?= htmlspecialchars($_GET['tags']) ?>
-                    </span>
-                  <?php endif; ?>
-                </div>
-              </div>
-              <?php endif; ?>
-
-              <div class="overflow-x-auto">
+<?php
+  $items_per_page = 5;
+  $count_stmt = $db->prepare("SELECT COUNT(*) as total FROM pastes WHERE is_public = 1 AND zero_knowledge = 0 AND (expire_time IS NULL OR expire_time > ?) AND parent_paste_id IS NULL");
+  $count_stmt->execute([time()]);
+  $total_count = $count_stmt->fetch()["total"];
+  $current_page = isset($_GET["p"]) ? max(1, intval($_GET["p"])) : 1;
+  $offset = ($current_page - 1) * $items_per_page;
+  $total_pages = ceil($total_count / $items_per_page);
+  $stmt = $db->prepare("SELECT p.*, u.username, (SELECT COUNT(*) FROM comments WHERE paste_id = p.id) as comment_count, COALESCE(p.fork_count, 0) as fork_count, CASE WHEN p.original_paste_id IS NOT NULL THEN 1 ELSE 0 END as is_fork, p.original_paste_id, p.parent_paste_id, (SELECT COUNT(*) FROM pastes WHERE parent_paste_id = p.id AND is_public = 1 AND zero_knowledge = 0) as child_count FROM pastes p LEFT JOIN users u ON p.user_id = u.id WHERE p.is_public = 1 AND p.zero_knowledge = 0 AND (p.expire_time IS NULL OR p.expire_time > ?) AND p.parent_paste_id IS NULL ORDER BY p.created_at DESC LIMIT ? OFFSET ?");
+  $stmt->execute([time(), $items_per_page, $offset]);
+  $archive_pastes = $stmt->fetchAll();
+?>
+                <div class="overflow-x-auto">
                 <table class="w-full table-auto">
                   <thead>
                     <tr class="bg-gray-100 dark:bg-gray-700">
@@ -6251,11 +6056,8 @@ plt.show()</code></pre>
                     <?php if (empty($archive_pastes)): ?>
                       <tr>
                         <td colspan="6" class="px-4 py-8 text-center text-gray-500 dark:text-gray-400">
-                          <i class="fas fa-search text-4xl mb-4"></i>
-                          <p class="text-lg">No pastes found matching your criteria.</p>
-                          <p class="text-sm">Try adjusting your search filters or 
-                            <a href="?page=archive" class="text-blue-500 hover:text-blue-700">clear all filters</a>
-                          </p>
+                          <i class="fas fa-archive text-4xl mb-4"></i>
+                          <p class="text-lg">No pastes found in the archive.</p>
                         </td>
                       </tr>
                     <?php else: ?>
@@ -6416,72 +6218,6 @@ plt.show()</code></pre>
               <script>
                 let loadedChildren = new Set();
 
-                // Toggle advanced filters
-                function toggleAdvancedFilters() {
-                  const filters = document.getElementById('advancedFilters');
-                  const button = event.target.closest('button');
-                  const icon = button.querySelector('i');
-
-                  filters.classList.toggle('hidden');
-                  if (filters.classList.contains('hidden')) {
-                    icon.className = 'fas fa-sliders-h';
-                  } else {
-                    icon.className = 'fas fa-times';
-                  }
-                }
-
-                // Enhanced search functionality
-                function quickFilter(type, value) {
-                  const form = document.getElementById('searchForm');
-
-                  if (type === 'date_range' && value === 'week') {
-                    const oneWeekAgo = new Date();
-                    oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
-                    document.querySelector('input[name="date_from"]').value = oneWeekAgo.toISOString().split('T')[0];
-                    document.querySelector('input[name="date_to"]').value = new Date().toISOString().split('T')[0];
-                    // Show advanced filters when date range is used
-                    document.getElementById('advancedFilters').classList.remove('hidden');
-                  } else {
-                    document.querySelector(`[name="${type}"]`).value = value;
-                  }
-
-                  form.submit();
-                }
-
-                // Auto-submit search form on sort change
-                document.querySelector('select[name="sort_by"]').addEventListener('change', function() {
-                  document.getElementById('searchForm').submit();
-                });
-
-                // Search suggestions for user input
-                const userInput = document.querySelector('input[name="user"]');
-                if (userInput) {
-                  let searchTimeout;
-                  userInput.addEventListener('input', function() {
-                    clearTimeout(searchTimeout);
-                    searchTimeout = setTimeout(() => {
-                      if (this.value.length >= 2) {
-                        fetch(`?action=search_users&term=${encodeURIComponent(this.value)}`)
-                          .then(response => response.json())
-                          .then(users => {
-                            // Simple autocomplete could be implemented here
-                            console.log('Found users:', users);
-                          })
-                          .catch(error => console.log('Search error:', error));
-                      }
-                    }, 300);
-                  });
-                }
-
-                // Real-time search (optional)
-                let realTimeSearchTimeout;
-                document.querySelector('input[name="search"]').addEventListener('input', function() {
-                  clearTimeout(realTimeSearchTimeout);
-                  realTimeSearchTimeout = setTimeout(() => {
-                    // Optional: implement real-time search
-                    // document.getElementById('searchForm').submit();
-                  }, 1000);
-                });
 
                 function toggleChildren(parentId) {
                   const childrenRow = document.getElementById(`children-${parentId}`);
@@ -6616,7 +6352,7 @@ plt.show()</code></pre>
               </script>
             </div>
           <?php elseif (!isset($_GET['page']) || $_GET['page'] === 'home'): ?>
-          <form method="POST" class="box paste-box bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 animate-fade-in" onsubmit="return validatePasteForm(event)">
+          <form method="POST" id="createPasteForm" class="box paste-box bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 animate-fade-in" onsubmit="return handlePasteSubmit(event)">
             <script>
               // Paste validation settings from PHP
               const maxPasteSize = <?= SiteSettings::get('max_paste_size', 0) ?>;
@@ -6661,6 +6397,37 @@ plt.show()</code></pre>
                 }
                 <?php endif; ?>
 
+                return true;
+              }
+
+              let zkKey = null;
+              let zkEncrypted = false;
+
+              async function encryptContent() {
+                const textarea = document.querySelector('textarea[name="content"]');
+                if (!textarea || zkEncrypted || !textarea.value.trim()) return;
+                const data = new TextEncoder().encode(textarea.value);
+                const keyBytes = window.crypto.getRandomValues(new Uint8Array(32));
+                const iv = window.crypto.getRandomValues(new Uint8Array(12));
+                const cryptoKey = await window.crypto.subtle.importKey('raw', keyBytes, {name: 'AES-GCM'}, false, ['encrypt']);
+                const encrypted = await window.crypto.subtle.encrypt({name: 'AES-GCM', iv}, cryptoKey, data);
+                const combined = new Uint8Array(iv.byteLength + encrypted.byteLength);
+                combined.set(iv, 0);
+                combined.set(new Uint8Array(encrypted), iv.byteLength);
+                textarea.value = btoa(String.fromCharCode(...combined));
+                zkKey = btoa(String.fromCharCode(...keyBytes));
+                zkEncrypted = true;
+                sessionStorage.setItem('zkKey', zkKey);
+              }
+
+              function handlePasteSubmit(event) {
+                const valid = validatePasteForm(event);
+                if (!valid) return false;
+
+                const zkBox = document.getElementById('zeroKnowledge');
+                if (zkBox && zkBox.checked && zkKey) {
+                  sessionStorage.setItem('zkKey', zkKey);
+                }
                 return true;
               }
 
@@ -6758,15 +6525,40 @@ plt.show()</code></pre>
                 if (contentTextarea) {
                   updateContentStats();
                   contentTextarea.addEventListener('input', updateContentStats);
+                  contentTextarea.addEventListener('blur', () => {
+                    const zkBox = document.getElementById('zeroKnowledge');
+                    if (zkBox && zkBox.checked) {
+                      encryptContent();
+                    }
+                  });
                 }
               });
             </script>
             <div class="space-y-6">
 
+  <div class="flex justify-between items-center mb-4">
+    <a href="index.php" class="text-blue-500 hover:text-blue-700 font-semibold flex items-center">
+      <i class="fas fa-plus mr-1"></i>Create New Paste
+    </a>
+    <div class="space-x-2">
+      <button type="button" id="loadTemplateBtn" class="border border-gray-300 bg-white dark:bg-gray-700 dark:border-gray-600 px-3 py-1 rounded text-sm hover:bg-gray-100 dark:hover:bg-gray-600">Load Template</button>
+      <button type="button" id="importBtn" class="border border-gray-300 bg-white dark:bg-gray-700 dark:border-gray-600 px-3 py-1 rounded text-sm hover:bg-gray-100 dark:hover:bg-gray-600">Import</button>
+      <input type="file" id="importFile" accept=".php,.py,.js,.java,.cpp,.c,.cs,.rb,.go,.ts,.swift,.txt" class="hidden">
+    </div>
+  </div>
 
               <div class="paste-form-element">
                 <label class="block text-sm font-medium mb-2">Title</label>
                 <input type="text" name="title" required class="w-full px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 dark:bg-gray-700 focus:ring-2 focus:ring-blue-500 transition-all" placeholder="Enter paste title">
+              </div>
+
+              <div class="paste-form-element">
+                <label class="flex items-center space-x-2">
+                  <input type="checkbox" name="zero_knowledge" id="zeroKnowledge" class="rounded">
+                  <span>🔐 Make this a Zero-Knowledge Paste</span>
+                  <span title="Encrypt your paste client-side. Server will never see the content. This must be selected before typing your content." class="cursor-help">ℹ️</span>
+                </label>
+                <p class="text-xs text-gray-500 mt-1">If you lose this link, the paste cannot be recovered.</p>
               </div>
 
               <div class="field">
@@ -6788,10 +6580,16 @@ plt.show()</code></pre>
                 </div>
               </div>
 
-              <div class="grid md:grid-cols-2 gap-4">
-                <div>
-                  <label class="block text-sm font-medium mb-1">Language:</label>
-                  <select name="language" class="w-full p-2 rounded border dark:bg-gray-700 dark:border-gray-600">
+              <button type="button" id="toggleAdvanced" class="text-sm font-medium text-left w-full flex items-center justify-between bg-gray-100 dark:bg-gray-800 px-4 py-2 rounded">
+                <span>⚙️ Advanced Options</span>
+                <span id="advArrow" class="ml-2">▲</span>
+              </button>
+
+              <div id="advancedOptions" class="space-y-6 hidden">
+                <div class="grid md:grid-cols-2 gap-4">
+                  <div>
+                    <label class="block text-sm font-medium mb-1">Language:</label>
+                    <select name="language" class="w-full p-2 rounded border dark:bg-gray-700 dark:border-gray-600">
                     <option value="plaintext">Plain Text</option>
                     <option value="abap">ABAP</option>
                     <option value="actionscript">ActionScript</option>
@@ -6949,6 +6747,10 @@ plt.show()</code></pre>
                     <option value="3600">1 hour</option>
                     <option value="86400">1 day</option>
                     <option value="604800">1 week</option>
+                    <option value="1209600">2 Weeks</option>
+                    <option value="2592000">1 Month</option>
+                    <option value="15552000">6 Months</option>
+                    <option value="31536000">1 Year</option>
                   </select>
                 </div>
               </div>
@@ -6980,12 +6782,24 @@ plt.show()</code></pre>
 
               <div class="grid md:grid-cols-2 gap-4 paste-form-element">
                 <div>
-                  <label class="flex items-center space-x-2">
-                    <input type="checkbox" name="is_public" checked class="rounded">
-                    <span>Public paste</span>
-                  </label>
+                  <span class="block text-sm font-medium mb-1">Visibility:</span>
+                  <div class="flex items-center space-x-4">
+                    <label class="flex items-center space-x-1">
+                      <input type="radio" name="visibility" value="public" checked class="rounded">
+                      <span>Public</span>
+                    </label>
+                    <label class="flex items-center space-x-1">
+                      <input type="radio" name="visibility" value="unlisted" class="rounded">
+                      <span>Unlisted</span>
+                    </label>
+                    <label class="flex items-center space-x-1">
+                      <input type="radio" name="visibility" value="private" class="rounded">
+                      <span>Private</span>
+                    </label>
+                  </div>
+                  <input type="hidden" name="is_public" id="is_public_hidden" value="1">
                 </div>
-                <div>
+                <div class="flex items-center mt-6">
                   <label class="flex items-center space-x-2">
                     <input type="checkbox" name="burn_after_read" class="rounded">
                     <span>Burn after reading</span>
@@ -6998,15 +6812,17 @@ plt.show()</code></pre>
                 <input type="password" name="password" class="w-full px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 dark:bg-gray-700" placeholder="Password protect this paste">
               </div>
 
-              <!-- Hidden input for parent paste ID (for paste chains) -->
-              <input type="hidden" name="parent_paste_id" value="<?php echo htmlspecialchars($_GET['parent_id'] ?? ''); ?>">
-
-              <div class="text-center paste-form-element">
-                <button type="submit" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-8 rounded-lg transition-all transform hover:scale-105">
-                  <i class="fas fa-plus mr-2"></i>Create Paste
-                </button>
-              </div>
             </div>
+
+            <!-- Hidden input for parent paste ID (for paste chains) -->
+            <input type="hidden" name="parent_paste_id" value="<?php echo htmlspecialchars($_GET['parent_id'] ?? ''); ?>">
+
+            <div class="text-center paste-form-element">
+              <button type="submit" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-8 rounded-lg transition-all transform hover:scale-105">
+                <i class="fas fa-plus mr-2"></i>Create Paste
+              </button>
+            </div>
+          </div>
           </form>
           <?php endif; ?>
           <?php endif; ?>
@@ -7014,6 +6830,34 @@ plt.show()</code></pre>
       </div>
     </div>
   </div>
+<!-- Template Modal -->
+<div id="templateModal" class="hidden fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
+  <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg max-w-md w-full">
+    <div class="flex justify-between items-center p-6 border-b dark:border-gray-700">
+      <h3 class="text-lg font-semibold">Load Template</h3>
+      <button onclick="closeTemplateModal()" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+        <i class="fas fa-times text-xl"></i>
+      </button>
+    </div>
+    <div class="p-6 space-y-6">
+      <div id="languageList" class="grid grid-cols-2 gap-3">
+        <button type="button" data-lang="python" class="language-item px-3 py-2 border rounded">Python</button>
+        <button type="button" data-lang="javascript" class="language-item px-3 py-2 border rounded">JavaScript</button>
+        <button type="button" data-lang="php" class="language-item px-3 py-2 border rounded">PHP</button>
+        <button type="button" data-lang="cpp" class="language-item px-3 py-2 border rounded">C++</button>
+        <button type="button" data-lang="java" class="language-item px-3 py-2 border rounded">Java</button>
+        <button type="button" data-lang="go" class="language-item px-3 py-2 border rounded">Go</button>
+        <button type="button" data-lang="ruby" class="language-item px-3 py-2 border rounded">Ruby</button>
+        <button type="button" data-lang="rust" class="language-item px-3 py-2 border rounded">Rust</button>
+        <button type="button" data-lang="csharp" class="language-item px-3 py-2 border rounded">C#</button>
+        <button type="button" data-lang="swift" class="language-item px-3 py-2 border rounded">Swift</button>
+      </div>
+      <div class="text-right">
+        <button type="button" id="loadTemplateConfirm" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">Load</button>
+      </div>
+    </div>
+  </div>
+</div>
 
   <script>
     function editPaste(id) {
@@ -7040,7 +6884,7 @@ plt.show()</code></pre>
       })
     }
 
-    function openCollectionModal() {
+  function openCollectionModal() {
       const modal = document.getElementById('collectionModal');
       if (modal) {
         modal.classList.remove('hidden');
@@ -7068,11 +6912,109 @@ plt.show()</code></pre>
 
     // Close modal with Escape key
     document.addEventListener('keydown', function(e) {
-      if (e.key === 'Escape') {
-        closeCollectionModal();
+    if (e.key === 'Escape') {
+      closeCollectionModal();
+    }
+  });
+
+  // Advanced options toggle
+  const advToggle = document.getElementById('toggleAdvanced');
+  const advSection = document.getElementById('advancedOptions');
+  const advArrow = document.getElementById('advArrow');
+  if (advToggle && advSection && advArrow) {
+    advToggle.addEventListener('click', () => {
+      advSection.classList.toggle('hidden');
+      if (advSection.classList.contains('hidden')) {
+        advArrow.textContent = '▲';
+      } else {
+        advArrow.textContent = '▼';
       }
     });
+  }
 
+  // Visibility radio -> is_public handling
+  const visibilityRadios = document.querySelectorAll('input[name="visibility"]');
+  const isPublicHidden = document.getElementById('is_public_hidden');
+  visibilityRadios.forEach(radio => {
+    radio.addEventListener('change', () => {
+      if (radio.value === 'private') {
+        isPublicHidden.disabled = true;
+      } else {
+        isPublicHidden.disabled = false;
+      }
+    });
+  });
+
+// Template modal logic
+const templateBtn = document.getElementById("loadTemplateBtn");
+const templateModal = document.getElementById("templateModal");
+const languageItems = document.querySelectorAll("#languageList .language-item");
+const templateLoad = document.getElementById("loadTemplateConfirm");
+let selectedLang = null;
+const templateSnippets = {
+  python: "#!/usr/bin/env python3\n\"\"\"\nDescription: [Brief description of what this script does]\nAuthor: [Your name]\nDate: 2025-06-13\n\"\"\"\n\ndef main():\n    # Your code here\n    pass\n\nif __name__ == \"__main__\":\n    main()\n",
+  javascript: "#!/usr/bin/env node\n/**\n * Description: [Brief description of what this script does]\n * Author: [Your name]\n * Date: 2025-06-13\n */\nfunction main() {\n  // Your code here\n}\n\nmain();\n",
+  php: "<" + "?php\n/**\n * Description: [Brief description of what this script does]\n * Author: [Your name]\n * Date: 2025-06-13\n */\nfunction main() {\n    // Your code here\n}\n\nmain();\n",
+  cpp: "#include <iostream>\n\n// Description: [Brief description of what this program does]\n// Author: [Your name]\n// Date: 2025-06-13\n\nint main() {\n    // Your code here\n    return 0;\n}\n",
+  java: "/**\n * Description: [Brief description of what this program does]\n * Author: [Your name]\n * Date: 2025-06-13\n */\npublic class Main {\n    public static void main(String[] args) {\n        // Your code here\n    }\n}\n",
+  go: "package main\n\nimport \"fmt\"\n\n// Description: [Brief description of what this program does]\n// Author: [Your name]\n// Date: 2025-06-13\n\nfunc main() {\n    // Your code here\n    fmt.Println(\"Hello\")\n}\n",
+  ruby: "#!/usr/bin/env ruby\n# Description: [Brief description of what this script does]\n# Author: [Your name]\n# Date: 2025-06-13\n\ndef main\n  # Your code here\nend\n\nmain if __FILE__ == $PROGRAM_NAME\n",
+  rust: "// Description: [Brief description of what this program does]\n// Author: [Your name]\n// Date: 2025-06-13\n\nfn main() {\n    // Your code here\n}\n",
+  csharp: "using System;\n\n/// Description: [Brief description of what this program does]\n/// Author: [Your name]\n/// Date: 2025-06-13\nclass Program\n{\n    static void Main()\n    {\n        // Your code here\n    }\n}\n",
+  swift: "import Foundation\n// Description: [Brief description of what this script does]\n// Author: [Your name]\n// Date: 2025-06-13\n\nfunc main() {\n    // Your code here\n}\n\nmain()\n"
+};
+
+if (templateBtn) {
+  templateBtn.addEventListener('click', () => {
+    if (templateModal) templateModal.classList.remove('hidden');
+  });
+}
+if (templateModal) {
+  languageItems.forEach(btn => {
+    btn.addEventListener('click', () => {
+      languageItems.forEach(b => b.classList.remove('bg-blue-500','text-white'));
+      btn.classList.add('bg-blue-500','text-white');
+      selectedLang = btn.dataset.lang;
+    });
+  });
+}
+if (templateLoad) {
+  templateLoad.addEventListener('click', () => {
+    if (!selectedLang) return;
+    const textarea = document.querySelector('textarea[name="content"]');
+    const langSelect = document.querySelector('select[name="language"]');
+    if (textarea) textarea.value = templateSnippets[selectedLang] || '';
+    if (langSelect) langSelect.value = selectedLang;
+    closeTemplateModal();
+  });
+}
+function closeTemplateModal() {
+  if (templateModal) templateModal.classList.add('hidden');
+}
+document.addEventListener('click', e => {
+  if (templateModal && e.target === templateModal) {
+    closeTemplateModal();
+  }
+});
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape') closeTemplateModal();
+});
+// Import file logic
+const importBtnEl = document.getElementById("importBtn");
+const importFileInput = document.getElementById("importFile");
+if (importBtnEl && importFileInput) {
+  importBtnEl.addEventListener('click', () => importFileInput.click());
+  importFileInput.addEventListener('change', () => {
+    const file = importFileInput.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = e => {
+      const textarea = document.querySelector('textarea[name="content"]');
+      if (textarea) textarea.value = e.target.result;
+    };
+    reader.readAsText(file);
+  });
+}
     // Enhanced Share Modal Functions
     function openEnhancedShareModal(pasteId) {
       fetch('enhanced_paste_share.php', {
@@ -7894,6 +7836,8 @@ plt.show()</code></pre>
 
     // Auto-expand all replies on page load
     document.addEventListener('DOMContentLoaded', function() {
+      window.pasteDecrypted = false;
+      window.decryptedText = null;
       // Show all replies by default
       document.querySelectorAll('[id^="replies-"]').forEach(function(element) {
         element.classList.remove('hidden');
@@ -7912,6 +7856,47 @@ plt.show()</code></pre>
 
       // Initialize countdown timers
       initializeCountdownTimers();
+
+      <?php if (isset($paste) && $paste['zero_knowledge']): ?>
+      (async function() {
+        let match = window.location.hash.match(/key=([^&]+)/);
+        const container = document.getElementById('zkContent');
+        const banner = document.getElementById('zkPrivateLink');
+        if (!container) return;
+        if (!match) {
+          const stored = sessionStorage.getItem('zkKey');
+          if (stored) {
+            window.location.hash = 'key=' + encodeURIComponent(stored);
+            match = ['#key=' + stored, stored];
+            sessionStorage.removeItem('zkKey');
+          }
+        }
+        if (!match) {
+          container.textContent = 'This paste is encrypted. You must access it using the original link that includes the key.';
+          return;
+        }
+        try {
+          const keyBytes = Uint8Array.from(atob(decodeURIComponent(match[1])), c => c.charCodeAt(0));
+          const encData = Uint8Array.from(atob("<?= htmlspecialchars($paste['content'], ENT_QUOTES) ?>"), c => c.charCodeAt(0));
+          const iv = encData.slice(0,12);
+          const cipher = encData.slice(12);
+          const key = await crypto.subtle.importKey('raw', keyBytes, {name:'AES-GCM'}, false, ['decrypt']);
+          const decrypted = await crypto.subtle.decrypt({name:'AES-GCM', iv}, key, cipher);
+          const plain = new TextDecoder().decode(decrypted);
+          container.textContent = plain;
+          window.decryptedText = plain;
+          if (banner) {
+            const fullLink = window.location.href;
+            banner.innerHTML = `<strong>Private Link:</strong> <a href="${fullLink}" class="underline break-all">${fullLink}</a><br><em>Save this link — without the key, this paste cannot be recovered.</em>`;
+          }
+          if (window.Prism) Prism.highlightAllUnder(container.parentElement);
+          window.pasteDecrypted = true;
+          document.querySelectorAll('.zk-restricted').forEach(el => el.classList.remove('hidden'));
+        } catch (e) {
+          container.textContent = 'Failed to decrypt paste. The key may be invalid.';
+        }
+      })();
+      <?php endif; ?>
     });
 
     // Countdown timer functionality

--- a/paste.php
+++ b/paste.php
@@ -1,0 +1,16 @@
+<?php
+// Lightweight front controller to display a paste by ID using /paste/{id} URLs
+$path = trim($_SERVER['REQUEST_URI'], '/');
+$parts = explode('/', $path);
+$id = null;
+if (count($parts) >= 2 && $parts[0] === 'paste') {
+    $id = $parts[1];
+} elseif (!empty($_SERVER['PATH_INFO'])) {
+    $id = ltrim($_SERVER['PATH_INFO'], '/');
+}
+if ($id !== null) {
+    $_GET['id'] = $id;
+}
+require __DIR__ . '/index.php';
+
+

--- a/project_paste_viewer.php
+++ b/project_paste_viewer.php
@@ -3,7 +3,6 @@
 session_start();
 require_once 'database.php';
 require_once 'related_pastes_helper.php';
-require_once 'utility.php';
 
 if (!isset($_GET['id'])) {
     header('Location: /');
@@ -12,6 +11,26 @@ if (!isset($_GET['id'])) {
 
 $paste_id = $_GET['id'];
 $db = Database::getInstance()->getConnection();
+
+function human_time_diff($timestamp) {
+    if (!is_numeric($timestamp)) {
+        $timestamp = strtotime($timestamp);
+    }
+    $timestamp = intval($timestamp);
+    $diff = time() - $timestamp;
+    if ($diff < 60) return 'just now';
+    if ($diff < 3600) return floor($diff / 60) . ' minutes ago';
+    if ($diff < 86400) return floor($diff / 3600) . ' hours ago';
+
+    $days = floor($diff / 86400);
+    if ($days < 30) return $days . ' days ago';
+
+    $months = floor($days / 30);
+    if ($months < 12) return $months . ' month' . ($months > 1 ? 's' : '') . ' ago';
+
+    $years = floor($months / 12);
+    return $years . ' year' . ($years > 1 ? 's' : '') . ' ago';
+}
 
 // Check if this paste belongs to a project
 $stmt = $db->prepare("
@@ -604,4 +623,4 @@ document.addEventListener('DOMContentLoaded', () => {
 
 </body>
 </html>
-</replit_final_file>
+

--- a/related_pastes_helper.php
+++ b/related_pastes_helper.php
@@ -75,7 +75,7 @@ class RelatedPastesHelper {
         
         if (empty($conditions)) {
             // Fallback: just get recent public pastes
-            $conditions[] = "p.is_public = 1";
+            $conditions[] = "p.is_public = 1 AND p.zero_knowledge = 0";
             $params[] = 1;
         }
         
@@ -90,8 +90,8 @@ class RelatedPastesHelper {
                    END as relevance_score
             FROM pastes p
             LEFT JOIN users u ON p.user_id = u.id
-            WHERE p.id != ? 
-            AND p.is_public = 1 
+            WHERE p.id != ?
+            AND p.is_public = 1 AND p.zero_knowledge = 0
             AND (p.expire_time IS NULL OR p.expire_time > ?)
             AND ($where_clause)
             ORDER BY relevance_score DESC, p.created_at DESC
@@ -122,8 +122,8 @@ class RelatedPastesHelper {
             FROM paste_related_cache prc
             JOIN pastes p ON prc.related_paste_id = p.id
             LEFT JOIN users u ON p.user_id = u.id
-            WHERE prc.paste_id = ? 
-            AND p.is_public = 1 
+            WHERE prc.paste_id = ?
+            AND p.is_public = 1 AND p.zero_knowledge = 0
             AND (p.expire_time IS NULL OR p.expire_time > ?)
             ORDER BY prc.relevance_score DESC, p.created_at DESC
             LIMIT ?

--- a/setup-clean.php
+++ b/setup-clean.php
@@ -48,6 +48,7 @@ try {
       views INTEGER DEFAULT 0,
       user_id TEXT,
       burn_after_read BOOLEAN DEFAULT 0,
+      zero_knowledge INTEGER DEFAULT 0,
       flags INTEGER DEFAULT 0,
       flag_type TEXT,
       flag_source TEXT,

--- a/setup_paste_chains.php
+++ b/setup_paste_chains.php
@@ -37,6 +37,7 @@ try {
         user_id TEXT,
         views INTEGER DEFAULT 0,
         burn_after_read BOOLEAN DEFAULT 0,
+        zero_knowledge INTEGER DEFAULT 0,
         current_version INTEGER DEFAULT 1,
         last_modified INTEGER,
         flags INTEGER DEFAULT 0,


### PR DESCRIPTION
## Summary
- tweak burn-after-reading alignment with visibility controls
- encrypt zero-knowledge pastes when the content box loses focus
- store the encryption key and redirect after creation with the key in the URL
- ensure create button submits normally and save the key in sessionStorage
- hide raw/download/clone/fork actions until a zero-knowledge paste is decrypted
- hide comments and discussions tabs for encrypted pastes until decrypted
- hide Add to Chain until zero-knowledge paste is decrypted
- move the zero-knowledge checkbox next to the title field for better visibility
- hide zero-knowledge pastes from public listings
- use client-side download after decrypting zero-knowledge pastes
- fix include error in project paste viewer
- **remove Global Search UI from the archive page**

## Testing
- `php -l index.php` *(fails: command not found)*
- `php -l following.php` *(fails: command not found)*
- `php -l account.php` *(fails: command not found)*
- `php -l related_pastes_helper.php` *(fails: command not found)*
- `php -l enhanced_paste_share.php` *(fails: command not found)*
- `php -l project_paste_viewer.php` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684b5dd0b7f48321ba88a1d5ab63a7f9